### PR TITLE
Feature: Add option to add additional tag to all notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,21 +98,23 @@ enex2paperless.exe MyEnexFile.enex -o myfoldername
 
 This disables uploads to Paperless and only outputs files to your provided folder.
 
-### Additional Tag
+### Additional Tags / Filename As Tag
 
-You can add an additional tag to all files being processed using the `-t` flag:
-
-```shell
-enex2paperless.exe MyEnexFile.enex -t "migration2024"
-```
-
-If you provide the `-t` flag without a value, the ENEX filename (without extension) will be used as the additional tag:
+You can add additional tags to all files being processed using the `-t` flag and a comma separated list of strings:
 
 ```shell
-enex2paperless.exe MyEnexFile.enex -t ""
+enex2paperless.exe MyEnexFile.enex -t migration2024,taxes,important
 ```
 
-This will add "MyEnexFile" as a tag to all processed files. If you don't use the `-t` flag at all, no additional tag will be added, and only the original Evernote tags will be preserved.
+If you set the `-T` flag, the ENEX filename (without extension) will be used as an additional tag:
+
+```shell
+enex2paperless.exe MyEnexFile.enex -T
+```
+
+This will add "MyEnexFile" as a tag to all processed files. 
+
+If you use neither the `-t` or `-T` flags, no additional tags will be added, and only the original Evernote tags will be preserved.
 
 ### Verbose Logging
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Flags:
   -h, --help                  help for enex2paperless
   -n, --nocolor               Disable colored output
   -o, --outputfolder string   Output attachements to this folder, NOT paperless.
+  -t, --tag string            Additional tag to add to all files. .enex filename is used if string is empty.
   -v, --verbose               Enable verbose logging
 ```
 
@@ -96,6 +97,22 @@ enex2paperless.exe MyEnexFile.enex -o myfoldername
 ```
 
 This disables uploads to Paperless and only outputs files to your provided folder.
+
+### Additional Tag
+
+You can add an additional tag to all files being processed using the `-t` flag:
+
+```shell
+enex2paperless.exe MyEnexFile.enex -t "migration2024"
+```
+
+If you provide the `-t` flag without a value, the ENEX filename (without extension) will be used as the additional tag:
+
+```shell
+enex2paperless.exe MyEnexFile.enex -t ""
+```
+
+This will add "MyEnexFile" as a tag to all processed files. If you don't use the `-t` flag at all, no additional tag will be added, and only the original Evernote tags will be preserved.
 
 ### Verbose Logging
 

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/spf13/cobra"
@@ -71,6 +73,23 @@ func main() {
 			if outputfolder != "" {
 				config.SetOutputFolder(outputfolder)
 			}
+
+			// Set additional tag if provided, otherwise use ENEX filename
+			tag, err := cmd.Flags().GetString("tag")
+			if err != nil {
+				fmt.Println("Error retrieving tag flag:", err)
+				os.Exit(1)
+			}
+
+			// Check if -t flag was provided (even if empty)
+			if cmd.Flags().Changed("tag") {
+				// If -t was provided but empty, use the ENEX filename without extension
+				if tag == "" && len(args) > 0 {
+					filename := filepath.Base(args[0])
+					tag = strings.TrimSuffix(filename, filepath.Ext(filename))
+				}
+				config.SetAdditionalTag(tag)
+			}
 		},
 
 		// run main function
@@ -89,6 +108,9 @@ func main() {
 
 	var outputfolder string
 	rootCmd.PersistentFlags().StringVarP(&outputfolder, "outputfolder", "o", "", "Output attachements to this folder, NOT paperless.")
+
+	var tag string
+	rootCmd.PersistentFlags().StringVarP(&tag, "tag", "t", "", "Additional tag to add to all files. .enex filename is used if string is empty.")
 
 	// run root command
 	err := rootCmd.Execute()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,13 +21,13 @@ var (
 )
 
 type Config struct {
-	PaperlessAPI string   `validate:"required,http_url"`
-	Username     string   `validate:"required_with=Password"`
-	Password     string   `validate:"required_with=Username"`
-	Token        string   `validate:"required_without=Password"`
-	FileTypes    []string `validate:"required"`
-	OutputFolder string
-	AdditionalTag string
+	PaperlessAPI   string   `validate:"required,http_url"`
+	Username       string   `validate:"required_with=Password"`
+	Password       string   `validate:"required_with=Username"`
+	Token          string   `validate:"required_without=Password"`
+	FileTypes      []string `validate:"required"`
+	OutputFolder   string
+	AdditionalTags []string
 }
 
 // GetConfig initializes and returns the application configuration.
@@ -92,7 +92,7 @@ func SetOutputFolder(path string) error {
 	return nil
 }
 
-func SetAdditionalTag(tag string) error {
-	settings.AdditionalTag = tag
+func SetAdditionalTags(tags []string) error {
+	settings.AdditionalTags = tags
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Token        string   `validate:"required_without=Password"`
 	FileTypes    []string `validate:"required"`
 	OutputFolder string
+	AdditionalTag string
 }
 
 // GetConfig initializes and returns the application configuration.
@@ -88,5 +89,10 @@ func GetConfig() (Config, error) {
 
 func SetOutputFolder(path string) error {
 	settings.OutputFolder = path
+	return nil
+}
+
+func SetAdditionalTag(tag string) error {
+	settings.AdditionalTag = tag
 	return nil
 }


### PR DESCRIPTION
I added a feature to be able to add an additional tag to the imported files.
If the new argument `-t` or `--tag` is kept blank `-t ""`, the filename is used instead.
This enables all imported notes to be filtered after the notebook name.