### PR TITLE
Add filename to title for notes with > 2 files

### DIFF
--- a/pkg/enex/methods.go
+++ b/pkg/enex/methods.go
@@ -256,7 +256,7 @@ func (e *EnexFile) UploadFromNoteChannel(noteChannel, failedNoteChannel chan Not
 				filename := resource.ResourceAttributes.FileName
 				extension := filepath.Ext(filename)
 				filenameWithoutExt := strings.TrimSuffix(filename, extension)
-				documentTitle = fmt.Sprintf("%s - %s", note.Title, filenameWithoutExt)
+				documentTitle = fmt.Sprintf("%s | %s", note.Title, filenameWithoutExt)
 			} else {
 				documentTitle = note.Title
 			}

--- a/pkg/enex/methods.go
+++ b/pkg/enex/methods.go
@@ -249,8 +249,18 @@ func (e *EnexFile) UploadFromNoteChannel(noteChannel, failedNoteChannel chan Not
 			body := &bytes.Buffer{}
 			writer := multipart.NewWriter(body)
 
-			// Set form fields
-			err = writer.WriteField("title", note.Title)
+			// Set form fields with conditional title
+			var documentTitle string
+			if len(note.Resources) > 1 {
+				// Get filename without extension
+				filename := resource.ResourceAttributes.FileName
+				extension := filepath.Ext(filename)
+				filenameWithoutExt := strings.TrimSuffix(filename, extension)
+				documentTitle = fmt.Sprintf("%s - %s", note.Title, filenameWithoutExt)
+			} else {
+				documentTitle = note.Title
+			}
+			err = writer.WriteField("title", documentTitle)
 			if err != nil {
 				failedNoteChannel <- note
 				slog.Error("error setting form fields", "error", err)


### PR DESCRIPTION
In evernote its possible to store multiple files in a single note. I have notes where I store 10+ files. In paperless all file names are the same then.
This PR adds the original file name to the title if a note has > 2 files inside.
Before: `Notettile` -> After: `Notetitle - filename` (file extensions are omitted).
